### PR TITLE
Add sitemap generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     		"standard": "^10.0.3",
 		"pug": "^2.0.0-rc.4",
 		"markdown-it": "^8.4.0",
-		"highlight.js": "^9.12.0"
+		"highlight.js": "^9.12.0",
+		"sitemap": "^1.13.0"
 	}
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,7 @@
 const fse = require('fs-extra')
 const path = require('path')
 const ejs = require('ejs')
+const sitemap = require('sitemap')
 const hljs = require('highlight.js')
 const { promisify } = require('util')
 const pug = require('pug')

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,6 +19,7 @@ const markdownIt = require('markdown-it')({
 const frontMatter = require('front-matter')
 const globP = promisify(require('glob'))
 const config = require('../site.config')
+const configData = Object.assign({}, config)
 
 const ejsRenderFile = promisify(ejs.renderFile)
 const distPath = './site'
@@ -31,6 +32,16 @@ fse.emptyDirSync(distPath)
 
 // copy static folder
 fse.copy(`static`, `${distPath}`)
+
+// generate sitemap
+const sitemapFile = sitemap.createSitemapIndex({
+      cacheTime: 600000,
+      hostname: configData.site.base_url,
+      sitemapName: 'sitemap',
+      sitemapSize: 1,
+      urls: configData.site.index_urls
+    });
+fse.writeFile(`${destPath}/sitemap.xml`, sitemapFile)
 
 // read pages
 globP('**/*.@(md|markdown|html|pug)', { cwd: `content` })

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,7 +41,7 @@ const sitemapFile = sitemap.createSitemapIndex({
       sitemapSize: 1,
       urls: configData.site.index_urls
     });
-fse.writeFile(`${destPath}/sitemap.xml`, sitemapFile)
+fse.writeFile(`${distPath}/sitemap.xml`, sitemapFile)
 
 // read pages
 globP('**/*.@(md|markdown|html|pug)', { cwd: `content` })

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -36,10 +36,10 @@ fse.copy(`static`, `${distPath}`)
 // generate sitemap
 const sitemapFile = sitemap.createSitemapIndex({
       cacheTime: 600000,
-      hostname: configData.site.base_url,
+      hostname: 'https://luxaura.netlify.com',
       sitemapName: 'sitemap',
       sitemapSize: 1,
-      urls: configData.site.index_urls
+      urls: ['/index.html', '/syntax-highlighting.html']
     });
 fse.writeFile(`${distPath}/sitemap.xml`, sitemapFile)
 


### PR DESCRIPTION
A sitemap generator is part of making Luxaura.js "blog-aware". Once this pull request is finished and merged, a `sitemap.xml` file will be generated and added on each build using the `npm run build` command.